### PR TITLE
Fix invalid ping example in mcp_server.ex

### DIFF
--- a/lib/mcp_sse/mcp/mcp_server.ex
+++ b/lib/mcp_sse/mcp/mcp_server.ex
@@ -13,7 +13,7 @@ defmodule MCPServer do
 
         @impl true
         def handle_ping(request_id) do
-          {:ok, %{jsonrpc: "2.0", id: request_id, result: "pong"}}
+          {:ok, %{jsonrpc: "2.0", id: request_id, result: %{}}}
         end
 
         @impl true


### PR DESCRIPTION
this should fix the invalid example. Unfortunately many of the AI model learned the wrong thing based on the doc