### PR TITLE
Fix incorrect default server ping. Fix config documentation for phoenix

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.2
+erlang 27.2.1
 elixir 1.18.2-otp-27

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.2.1
+erlang 27.2
 elixir 1.18.2-otp-27

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ config :mime, :types, %{
 }
 
 # Configure the MCP Server
-config :nws_mcp_server, :mcp_server, MCP.DefaultServer
-# config :nws_mcp_server, :mcp_server, YourApp.YourMCPServer
+config :mcp_sse, :mcp_server, MCP.DefaultServer
+# config :mcp_sse, :mcp_server, YourApp.YourMCPServer
 ```
 
 2. Add to your dependencies in `mix.exs`:
@@ -42,7 +42,7 @@ end
 scope "/" do
   pipe_through :sse
   get "/sse", SSE.ConnectionPlug, :call
-  
+
   pipe_through :api
   post "/message", SSE.ConnectionPlug, :call
 end
@@ -83,7 +83,7 @@ end
 ```elixir
 defmodule YourApp.Router do
   use Plug.Router
-  
+
   plug Plug.Parsers,
     parsers: [:urlencoded, :json],
     pass: ["text/*"],
@@ -248,7 +248,7 @@ fetch('/message?sessionId=YOUR_SESSION_ID', {
 
 ### SSE Keepalive
 
-The SSE connection sends periodic keepalive pings to prevent connection timeouts. 
+The SSE connection sends periodic keepalive pings to prevent connection timeouts.
 You can configure the ping interval or disable it entirely:
 
 ```elixir

--- a/lib/mcp_sse/mcp/default_server.ex
+++ b/lib/mcp_sse/mcp/default_server.ex
@@ -15,7 +15,7 @@ defmodule MCP.DefaultServer do
      %{
        jsonrpc: "2.0",
        id: request_id,
-       result: "pong"
+       result: %{}
      }}
   end
 

--- a/test/mcp_sse/mcp/default_server_test.exs
+++ b/test/mcp_sse/mcp/default_server_test.exs
@@ -13,7 +13,7 @@ defmodule MCP.DefaultServerTest do
       assert {:ok, response} = DefaultServer.handle_ping(request_id)
       assert response.jsonrpc == "2.0"
       assert response.id == request_id
-      assert response.result == "pong"
+      assert response.result == %{}
     end
   end
 


### PR DESCRIPTION
Documentation for Phoenix had an invalid name to configure . Also the ping for the default server was not correct so fixing it as well